### PR TITLE
 Search /usr/local and always include extra dynamic libs 

### DIFF
--- a/ipopt-sys/build.rs
+++ b/ipopt-sys/build.rs
@@ -491,7 +491,7 @@ fn link(cnlp_install_path: PathBuf, link_info: LinkInfo, dynamic: bool) -> Resul
     } else {
         println!("cargo:rustc-link-lib=static=ipopt");
     }
-        // Order is important here. The most core libs should appear last.
+    // Order is important here. The most core libs should appear last.
     for path in link_info.search_paths {
         println!("cargo:rustc-link-search=native={}", path.display());
     }


### PR DESCRIPTION
1. I added /usr/local as a system prefix to search for ipopt.
2. I was getting a whole bunch of missing symbol errors during the linking phase when building it against my system ipopt. Including the other dynamic libraries that you were including during static linking fixed this. See if this is what you intended in the first place, or if this could cause issues.

As an interesting side note: in the descent_ipopt interface I only needed to include ipopt as a library to link to:

#[link(name = "ipopt")]
extern "C" {
...
}

I don't know if there is a difference in the linking phase for this build.rs type of approach vs the above. Linking has always confused me...