### PR TITLE
Upgrade bindgen

### DIFF
--- a/ipopt-sys/Cargo.toml
+++ b/ipopt-sys/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["non-linear", "optimization", "constrained", "ipopt", "unsafe"]
 approx = "0.3"
 
 [build-dependencies]
-bindgen = "0.51"
+bindgen = "0.55"
 curl = "0.4"
 tar = "0.4"
 flate2 = "1.0"


### PR DESCRIPTION
Hello,
One of my projects needed `bindgen = "0.55"` so I upgraded the dependencies of `ipopt-sys`, and here's a PR if that's of any use to you.
I tested the example and compared the result from before the upgrade and it works fine on my Ubuntu 20.04.
If there are other tests I can do to make sure I didn't break anything, please let me know!