### PR TITLE
Expose the new_x parameter in the Rust interface

### DIFF
--- a/examples/constrained_quadratic_minimization.rs
+++ b/examples/constrained_quadratic_minimization.rs
@@ -57,11 +57,11 @@ impl<C, J, H> BasicProblem for NLP<C, J, H> {
         x[1] = 0.8;
         true
     }
-    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
+    fn objective(&self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = quadratic(x[0], x[1]);
         true
     }
-    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         let grad = quadratic_grad(x[0], x[1]);
         grad_f[0] = grad[0];
         grad_f[1] = grad[1];
@@ -88,7 +88,7 @@ where
         g_u[0] = 1e20;
         true
     }
-    fn constraint(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
+    fn constraint(&self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
         g[0] = (self.constraint_f)(x[0], x[1]);
         true
     }
@@ -99,7 +99,7 @@ where
         jcol[1] = 1;
         true
     }
-    fn constraint_jacobian_values(&mut self, x: &[Number], _: bool, vals: &mut [Number]) -> bool {
+    fn constraint_jacobian_values(&self, x: &[Number], _: bool, vals: &mut [Number]) -> bool {
         let jac = (self.constraint_jac)(x[0], x[1]);
         vals[0] = jac[0];
         vals[1] = jac[1];
@@ -133,7 +133,7 @@ where
         true
     }
     fn hessian_values(
-        &mut self,
+        &self,
         x: &[Number],
         _: bool,
         obj_factor: Number,

--- a/examples/constrained_quadratic_minimization.rs
+++ b/examples/constrained_quadratic_minimization.rs
@@ -57,11 +57,11 @@ impl<C, J, H> BasicProblem for NLP<C, J, H> {
         x[1] = 0.8;
         true
     }
-    fn objective(&self, x: &[Number], obj: &mut Number) -> bool {
+    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = quadratic(x[0], x[1]);
         true
     }
-    fn objective_grad(&self, x: &[Number], grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         let grad = quadratic_grad(x[0], x[1]);
         grad_f[0] = grad[0];
         grad_f[1] = grad[1];
@@ -88,7 +88,7 @@ where
         g_u[0] = 1e20;
         true
     }
-    fn constraint(&self, x: &[Number], g: &mut [Number]) -> bool {
+    fn constraint(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
         g[0] = (self.constraint_f)(x[0], x[1]);
         true
     }
@@ -99,7 +99,7 @@ where
         jcol[1] = 1;
         true
     }
-    fn constraint_jacobian_values(&self, x: &[Number], vals: &mut [Number]) -> bool {
+    fn constraint_jacobian_values(&mut self, x: &[Number], _: bool, vals: &mut [Number]) -> bool {
         let jac = (self.constraint_jac)(x[0], x[1]);
         vals[0] = jac[0];
         vals[1] = jac[1];
@@ -133,8 +133,9 @@ where
         true
     }
     fn hessian_values(
-        &self,
+        &mut self,
         x: &[Number],
+        _: bool,
         obj_factor: Number,
         lambda: &[Number],
         vals: &mut [Number],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,12 +183,12 @@ pub trait BasicProblem {
     /// Objective function. This is the function being minimized.
     ///
     /// This function is internally called by Ipopt callback `eval_f`.
-    fn objective(&mut self, x: &[Number], new_x: bool, obj: &mut Number) -> bool;
+    fn objective(&self, x: &[Number], new_x: bool, obj: &mut Number) -> bool;
 
     /// The gradient of the objective function speficies the search direction to Ipopt.
     ///
     /// This function is internally called by Ipopt callback `eval_grad_f`.
-    fn objective_grad(&mut self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool;
+    fn objective_grad(&self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool;
 
     /// Provide custom variable scaling.
     ///
@@ -266,7 +266,7 @@ pub trait ConstrainedProblem: BasicProblem {
     /// This gives the value of each constraint.
     /// The output slice `g` is guaranteed to be the same size as `num_constraints`.
     /// This function is internally called by Ipopt callback `eval_g`.
-    fn constraint(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool;
+    fn constraint(&self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool;
     /// Specify lower and upper bounds, `g_l` and `g_u` respectively, on the constraint function.
     ///
     /// Both slices will have the same size as what `num_constraints` returns.
@@ -297,12 +297,7 @@ pub trait ConstrainedProblem: BasicProblem {
     /// Each value must correspond to the `row` and
     /// `column` as specified in `constraint_jacobian_indices`.
     /// This function is internally called by Ipopt callback `eval_jac_g`.
-    fn constraint_jacobian_values(
-        &mut self,
-        x: &[Number],
-        new_x: bool,
-        vals: &mut [Number],
-    ) -> bool;
+    fn constraint_jacobian_values(&self, x: &[Number], new_x: bool, vals: &mut [Number]) -> bool;
     /// Number of non-zeros in the Hessian matrix.
     ///
     /// This includes the constraint Hessian.
@@ -325,7 +320,7 @@ pub trait ConstrainedProblem: BasicProblem {
     /// multiplier).
     /// This function is internally called by Ipopt callback `eval_h`.
     fn hessian_values(
-        &mut self,
+        &self,
         x: &[Number],
         new_x: bool,
         obj_factor: Number,
@@ -1754,10 +1749,10 @@ mod tests {
             x.copy_from_slice(&self.init_point);
             true
         }
-        fn objective(&mut self, _: &[Number], _: bool, _: &mut Number) -> bool {
+        fn objective(&self, _: &[Number], _: bool, _: &mut Number) -> bool {
             true
         }
-        fn objective_grad(&mut self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
+        fn objective_grad(&self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
             true
         }
     }
@@ -1812,10 +1807,10 @@ mod tests {
             x.copy_from_slice(&self.init_point.clone());
             true
         }
-        fn objective(&mut self, _: &[Number], _: bool, _: &mut Number) -> bool {
+        fn objective(&self, _: &[Number], _: bool, _: &mut Number) -> bool {
             true
         }
-        fn objective_grad(&mut self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
+        fn objective_grad(&self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
             true
         }
     }
@@ -1833,13 +1828,13 @@ mod tests {
             g_u.copy_from_slice(&self.constraint_upper);
             true
         }
-        fn constraint(&mut self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
+        fn constraint(&self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
             true
         }
         fn constraint_jacobian_indices(&self, _: &mut [Index], _: &mut [Index]) -> bool {
             true
         }
-        fn constraint_jacobian_values(&mut self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
+        fn constraint_jacobian_values(&self, _: &[Number], _: bool, _: &mut [Number]) -> bool {
             true
         }
 
@@ -1851,7 +1846,7 @@ mod tests {
             true
         }
         fn hessian_values(
-            &mut self,
+            &self,
             _: &[Number],
             _: bool,
             _: Number,

--- a/tests/constrained_newton.rs
+++ b/tests/constrained_newton.rs
@@ -85,11 +85,11 @@ impl BasicProblem for NLP {
         }
         false
     }
-    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
+    fn objective(&self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2];
         true
     }
-    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         grad_f[0] = x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]);
         grad_f[1] = x[0] * x[3];
         grad_f[2] = x[0] * x[3] + 1.0;
@@ -124,7 +124,7 @@ impl ConstrainedProblem for NLP {
         g_u.swap_with_slice(vec![2.0e19, 40.0].as_mut_slice());
         true
     }
-    fn constraint(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
+    fn constraint(&self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
         g[0] = x[0] * x[1] * x[2] * x[3] + self.g_offset[0];
         g[1] = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] + x[3] * x[3] + self.g_offset[1];
         true
@@ -148,7 +148,7 @@ impl ConstrainedProblem for NLP {
         jcol[7] = 3;
         true
     }
-    fn constraint_jacobian_values(&mut self, x: &[Number], _: bool, vals: &mut [Number]) -> bool {
+    fn constraint_jacobian_values(&self, x: &[Number], _: bool, vals: &mut [Number]) -> bool {
         vals[0] = x[1] * x[2] * x[3]; /* 0,0 */
         vals[1] = x[0] * x[2] * x[3]; /* 0,1 */
         vals[2] = x[0] * x[1] * x[3]; /* 0,2 */
@@ -177,7 +177,7 @@ impl ConstrainedProblem for NLP {
         true
     }
     fn hessian_values(
-        &mut self,
+        &self,
         x: &[Number],
         _: bool,
         obj_factor: Number,

--- a/tests/constrained_newton.rs
+++ b/tests/constrained_newton.rs
@@ -85,11 +85,11 @@ impl BasicProblem for NLP {
         }
         false
     }
-    fn objective(&self, x: &[Number], obj: &mut Number) -> bool {
+    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2];
         true
     }
-    fn objective_grad(&self, x: &[Number], grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         grad_f[0] = x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]);
         grad_f[1] = x[0] * x[3];
         grad_f[2] = x[0] * x[3] + 1.0;
@@ -124,7 +124,7 @@ impl ConstrainedProblem for NLP {
         g_u.swap_with_slice(vec![2.0e19, 40.0].as_mut_slice());
         true
     }
-    fn constraint(&self, x: &[Number], g: &mut [Number]) -> bool {
+    fn constraint(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
         g[0] = x[0] * x[1] * x[2] * x[3] + self.g_offset[0];
         g[1] = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] + x[3] * x[3] + self.g_offset[1];
         true
@@ -148,7 +148,7 @@ impl ConstrainedProblem for NLP {
         jcol[7] = 3;
         true
     }
-    fn constraint_jacobian_values(&self, x: &[Number], vals: &mut [Number]) -> bool {
+    fn constraint_jacobian_values(&mut self, x: &[Number], _: bool, vals: &mut [Number]) -> bool {
         vals[0] = x[1] * x[2] * x[3]; /* 0,0 */
         vals[1] = x[0] * x[2] * x[3]; /* 0,1 */
         vals[2] = x[0] * x[1] * x[3]; /* 0,2 */
@@ -177,8 +177,9 @@ impl ConstrainedProblem for NLP {
         true
     }
     fn hessian_values(
-        &self,
+        &mut self,
         x: &[Number],
+        _: bool,
         obj_factor: Number,
         lambda: &[Number],
         vals: &mut [Number],

--- a/tests/dynamic_problem_size.rs
+++ b/tests/dynamic_problem_size.rs
@@ -75,7 +75,7 @@ impl BasicProblem for NLP {
         x.copy_from_slice(&self.x_start.borrow());
         true
     }
-    fn objective(&self, x: &[Number], obj: &mut Number) -> bool {
+    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = 0.0;
         for &val in x.iter() {
             *obj += (val - 1.0) * (val - 1.0);
@@ -83,7 +83,7 @@ impl BasicProblem for NLP {
         *obj *= 0.5;
         true
     }
-    fn objective_grad(&self, x: &[Number], grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         for (g, &val) in grad_f.iter_mut().zip(x.iter()) {
             *g = val - 1.0;
         }

--- a/tests/dynamic_problem_size.rs
+++ b/tests/dynamic_problem_size.rs
@@ -75,7 +75,7 @@ impl BasicProblem for NLP {
         x.copy_from_slice(&self.x_start.borrow());
         true
     }
-    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
+    fn objective(&self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = 0.0;
         for &val in x.iter() {
             *obj += (val - 1.0) * (val - 1.0);
@@ -83,7 +83,7 @@ impl BasicProblem for NLP {
         *obj *= 0.5;
         true
     }
-    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         for (g, &val) in grad_f.iter_mut().zip(x.iter()) {
             *g = val - 1.0;
         }

--- a/tests/unconstrained_approx_newton.rs
+++ b/tests/unconstrained_approx_newton.rs
@@ -54,11 +54,11 @@ impl BasicProblem for NLP {
         x.copy_from_slice(&self.x_start);
         true
     }
-    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
+    fn objective(&self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = (x[0] - 1.0) * (x[0] - 1.0) + (x[1] - 1.0) * (x[1] - 1.0);
         true
     }
-    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         grad_f[0] = 2.0 * (x[0] - 1.0);
         grad_f[1] = 2.0 * (x[1] - 1.0);
         true

--- a/tests/unconstrained_approx_newton.rs
+++ b/tests/unconstrained_approx_newton.rs
@@ -54,11 +54,11 @@ impl BasicProblem for NLP {
         x.copy_from_slice(&self.x_start);
         true
     }
-    fn objective(&self, x: &[Number], obj: &mut Number) -> bool {
+    fn objective(&mut self, x: &[Number], _: bool, obj: &mut Number) -> bool {
         *obj = (x[0] - 1.0) * (x[0] - 1.0) + (x[1] - 1.0) * (x[1] - 1.0);
         true
     }
-    fn objective_grad(&self, x: &[Number], grad_f: &mut [Number]) -> bool {
+    fn objective_grad(&mut self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
         grad_f[0] = 2.0 * (x[0] - 1.0);
         grad_f[1] = 2.0 * (x[1] - 1.0);
         true


### PR DESCRIPTION
The implementation of the `new_x` parameter, as discussed in #10. To avoid having to fallback on interior mutability, the trait methods that contain the `new_x` parameter also require a `&mut self` reference. I don't think that should be a limitation for a typical application.

Caching still needs to be implement on the model side. In my application, the evaluation of the objective and the constraints happens simultaneously and is expensive, therefore, caching the results improves the performance significantly and is worth the additional coding effort. In many simpler cases the argument will probably simply be ignored, which would also be the case, if the C interface is called directly without the Rust wrapper.