### PR TITLE
Derive `Clone` and `Copy` for IpoptOption

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,7 @@ pub trait ConstrainedProblem: BasicProblem {
 
 /// Type of option you can specify to Ipopt.
 /// This is used internally for conversion.
+#[derive(Clone, Copy)]
 pub enum IpoptOption<'a> {
     /// Numeric option.
     Num(f64),


### PR DESCRIPTION
Hi, another minor addition: Collecting solver options in a `Vec` or similar to pass them through an interface is hindered if the type is not cloneable or in this case even copyable. 