### PR TITLE
Fix panic syntax

### DIFF
--- a/ipopt-sys/build.rs
+++ b/ipopt-sys/build.rs
@@ -183,7 +183,7 @@ fn main() {
         }
     }
 
-    panic!(msg);
+    panic!("{}", msg);
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Miniscule change, but removes a warning that is shown while compiling any dependents.

In the meantime, would you be ok with releasing a new version with the recent changes? That would allow me to release some of the things I built on top of it.

Thank you!