### PR TITLE
move from `DaGenix/rust-crypto` to `RustCrypto/hashes` on `ipopt-sys`

### DIFF
--- a/ipopt-sys/Cargo.toml
+++ b/ipopt-sys/Cargo.toml
@@ -25,8 +25,9 @@ flate2 = "1.0"
 pkg-config = "0.3"
 cmake = "0.1"
 lazy_static = "1"
-rust-crypto = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 log = "0.4"
 env_logger = "0.11"
+md-5 = "0.10.6"
+sha1 = "0.10.6"

--- a/ipopt-sys/build.rs
+++ b/ipopt-sys/build.rs
@@ -441,16 +441,17 @@ fn load_link_info() -> Result<LinkInfo, Error> {
 }
 
 fn check_tarball_hashes(tarball_path: &Path, md5: &str, sha1: &str) -> Result<(), Error> {
-    use crypto::digest::Digest;
+    use md5::{Digest, Md5};
+    use sha1::Sha1;
     use std::io::Read;
 
     {
         let mut f = File::open(tarball_path)?;
         let mut buffer = Vec::new();
         f.read_to_end(&mut buffer)?;
-        let mut hasher = crypto::md5::Md5::new();
-        hasher.input(&buffer);
-        let dl_hex = hasher.result_str();
+        let mut hasher = Md5::new();
+        hasher.update(&buffer);
+        let dl_hex = format!("{:x}", hasher.finalize());
         if md5 != dl_hex {
             return Err(Error::HashMismatch);
         }
@@ -459,9 +460,9 @@ fn check_tarball_hashes(tarball_path: &Path, md5: &str, sha1: &str) -> Result<()
         let mut f = File::open(tarball_path)?;
         let mut buffer = Vec::new();
         f.read_to_end(&mut buffer)?;
-        let mut hasher = crypto::sha1::Sha1::new();
-        hasher.input(&buffer);
-        let dl_hex = hasher.result_str();
+        let mut hasher = Sha1::new();
+        hasher.update(&buffer);
+        let dl_hex = format!("{:x}", hasher.finalize());
         if sha1 != dl_hex {
             return Err(Error::HashMismatch);
         }


### PR DESCRIPTION
This PR modifies `ipopt-sys` to use [RustCrypto/hashes](github.com/RustCrypto/hashes) which is actively maintained, in constrast to [DaGenix/rust-crypto](https://github.com/DaGenix/rust-crypto) which hasn't been updated in 9 years.
[DaGenix/rust-crypto](https://github.com/DaGenix/rust-crypto) is currently affected by several security advisories: 
- https://rustsec.org/advisories/RUSTSEC-2016-0005 (rust-crypto unmaintained, resolution is move to RustCrypto, done in this PR)
- https://rustsec.org/advisories/RUSTSEC-2025-0121
- https://rustsec.org/advisories/RUSTSEC-2022-0011
- https://rustsec.org/advisories/RUSTSEC-2022-0004 (due to dep on rustc-serialize 0.3.25)
- https://rustsec.org/advisories/RUSTSEC-2025-0025 (due to dep on rustc-serialize 0.3.25)
- https://rustsec.org/advisories/RUSTSEC-2020-0071 (due to dep on time 0.1.45)

I understand that the usage of rust-crypto in ipopt-sys is probably not affected by these advisories, however, running a tool like `cargo deny check` on a project depending on `ipopt` will result in a failure due to these advisories.
The change in this PR allows dependents of ipopt to pass this check without any problem (or exception, which might be a problem if the advisories are relevant in other parts of the project).