### PR TITLE
Pass the current primal iterate through ipopt-sys intermediate callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/ipopt-rs"
 keywords = ["non-linear", "optimization", "constrained", "ipopt", "newton"]
 
 [dependencies]
-ipopt-sys = { path = "ipopt-sys", version = "0.6" }
+ipopt-sys = { path = "ipopt-sys", version = "0.7" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/ipopt-sys/Cargo.toml
+++ b/ipopt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipopt-sys"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Egor Larionov <egor.larionov@gmail.com>"]
 build = "build.rs"
 license = "MIT OR Apache-2.0"

--- a/ipopt-sys/build.rs
+++ b/ipopt-sys/build.rs
@@ -124,6 +124,12 @@ fn init_logger() {
 
 fn main() {
     init_logger();
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=cnlp/CMakeLists.txt");
+    println!("cargo:rerun-if-changed=cnlp/src/c_api.cpp");
+    println!("cargo:rerun-if-changed=cnlp/src/c_api.h");
+    println!("cargo:rerun-if-changed=cnlp/src/nlp.cpp");
+    println!("cargo:rerun-if-changed=cnlp/src/nlp.hpp");
 
     let mut msg = String::from("\n\n");
 

--- a/ipopt-sys/cnlp/src/c_api.h
+++ b/ipopt-sys/cnlp/src/c_api.h
@@ -169,7 +169,8 @@ extern "C"
             CNLP_Number mu, CNLP_Number d_norm,
             CNLP_Number regularization_size,
             CNLP_Number alpha_du, CNLP_Number alpha_pr,
-            CNLP_Index ls_trials, CNLP_UserDataPtr user_data);
+            CNLP_Index ls_trials, CNLP_Index x_count,
+            const CNLP_Number* x, CNLP_UserDataPtr user_data);
 
     /** Enum reporting the status of problem creation */
     enum CNLP_CreateProblemStatus {

--- a/ipopt-sys/cnlp/src/nlp.cpp
+++ b/ipopt-sys/cnlp/src/nlp.cpp
@@ -1,6 +1,9 @@
 #include "nlp.hpp"
 #include <coin/IpIpoptApplication.hpp>
 #include <coin/IpBlas.hpp>
+#include <coin/IpIpoptData.hpp>
+#include <coin/IpIteratesVector.hpp>
+#include <coin/IpDenseVector.hpp>
 
 #include <algorithm>
 
@@ -328,9 +331,23 @@ bool CNLP_Problem::intermediate_callback(
 {
     CNLP_Bool retval = 1;
     if (m_intermediate_cb && *m_intermediate_cb) {
+        const Ipopt::Number* x_values = nullptr;
+        Ipopt::Index x_count = 0;
+        if (ip_data != nullptr) {
+            Ipopt::SmartPtr<const Ipopt::IteratesVector> current_iterates = ip_data->curr();
+            if (Ipopt::IsValid(current_iterates)) {
+                Ipopt::SmartPtr<const Ipopt::Vector> current_x = current_iterates->x();
+                const auto* dense_x =
+                    dynamic_cast<const Ipopt::DenseVector*>(Ipopt::GetRawPtr(current_x));
+                if (dense_x != nullptr) {
+                    x_count = dense_x->Dim();
+                    x_values = dense_x->ExpandedValues();
+                }
+            }
+        }
         retval = (**m_intermediate_cb)(convert_algorithm_mode(mode), iter, obj_value, inf_pr, inf_du,
                 mu, d_norm, regularization_size, alpha_du,
-                alpha_pr, ls_trials, m_user_data);
+                alpha_pr, ls_trials, x_count, x_values, m_user_data);
     }
     return (retval!=0);
 }
@@ -357,4 +374,3 @@ void CNLP_Problem::finalize_solution(
     m_obj_sol = obj_value;
     // don't need to store the status, we get the status from the OptimizeTNLP method
 }
-

--- a/ipopt-sys/src/lib.rs
+++ b/ipopt-sys/src/lib.rs
@@ -455,8 +455,13 @@ mod tests {
         _alpha_du: CNLP_Number,
         _alpha_pr: CNLP_Number,
         _ls_trials: CNLP_Index,
+        x_count: CNLP_Index,
+        x: *const CNLP_Number,
         _user_data: CNLP_UserDataPtr,
     ) -> CNLP_Bool {
+        let x = unsafe { slice::from_raw_parts(x, x_count as usize) };
+        assert_eq!(x.len(), 4);
+        assert!(x.iter().all(|value| value.is_finite()));
         (inf_pr >= 1e-4) as CNLP_Bool
     }
 }


### PR DESCRIPTION
This updates the `ipopt-sys` side of the stack to pass the current primal iterate through the CNLP intermediate callback instead of only forwarding scalar diagnostics.

What changed:
- extend `CNLP_Intermediate_CB` with `(x_count, x)`
- read `ip_data->curr()->x()` in the CNLP C++ bridge and forward it
- add `cargo:rerun-if-changed` entries so bindgen/CNLP rebuild when the shim changes
- bump `ipopt-sys` from `0.6.0` to `0.7.0`
- update the root crate's `ipopt-sys` dependency constraint from `0.6` to `0.7` so the workspace remains internally compatible
- strengthen the raw callback test to assert that the iterate slice is present and finite

Why the version bump:
- this is a breaking change for direct `ipopt-sys` users because the raw intermediate callback signature changes
- under `0.x`, that should be a minor bump, so this PR uses `0.7.0`

This is intended to be the first half of a two-step release:
1. `ipopt-sys 0.7.0` exposes the primal iterate through the raw callback surface
2. `ipopt 0.7.0` exposes it in `IntermediateCallbackData`

I have a follow-up PR prepared for the safe `ipopt` crate once this raw-layer shape looks reasonable.
