### PR TITLE
Expose the primal iterate through ipopt-sys and ipopt intermediate callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/ipopt-rs"
 keywords = ["non-linear", "optimization", "constrained", "ipopt", "newton"]
 
 [dependencies]
-ipopt-sys = { path = "ipopt-sys", version = "0.6" }
+ipopt-sys = { path = "ipopt-sys", version = "0.7" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipopt"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Egor Larionov <egor.larionov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Rust language bindings for the Ipopt non-linear constrained optimization library."

--- a/ipopt-sys/Cargo.toml
+++ b/ipopt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipopt-sys"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Egor Larionov <egor.larionov@gmail.com>"]
 build = "build.rs"
 license = "MIT OR Apache-2.0"

--- a/ipopt-sys/build.rs
+++ b/ipopt-sys/build.rs
@@ -124,6 +124,12 @@ fn init_logger() {
 
 fn main() {
     init_logger();
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=cnlp/CMakeLists.txt");
+    println!("cargo:rerun-if-changed=cnlp/src/c_api.cpp");
+    println!("cargo:rerun-if-changed=cnlp/src/c_api.h");
+    println!("cargo:rerun-if-changed=cnlp/src/nlp.cpp");
+    println!("cargo:rerun-if-changed=cnlp/src/nlp.hpp");
 
     let mut msg = String::from("\n\n");
 

--- a/ipopt-sys/cnlp/src/c_api.h
+++ b/ipopt-sys/cnlp/src/c_api.h
@@ -169,7 +169,8 @@ extern "C"
             CNLP_Number mu, CNLP_Number d_norm,
             CNLP_Number regularization_size,
             CNLP_Number alpha_du, CNLP_Number alpha_pr,
-            CNLP_Index ls_trials, CNLP_UserDataPtr user_data);
+            CNLP_Index ls_trials, CNLP_Index x_count,
+            const CNLP_Number* x, CNLP_UserDataPtr user_data);
 
     /** Enum reporting the status of problem creation */
     enum CNLP_CreateProblemStatus {

--- a/ipopt-sys/cnlp/src/nlp.cpp
+++ b/ipopt-sys/cnlp/src/nlp.cpp
@@ -1,6 +1,9 @@
 #include "nlp.hpp"
 #include <coin/IpIpoptApplication.hpp>
 #include <coin/IpBlas.hpp>
+#include <coin/IpIpoptData.hpp>
+#include <coin/IpIteratesVector.hpp>
+#include <coin/IpDenseVector.hpp>
 
 #include <algorithm>
 
@@ -328,9 +331,23 @@ bool CNLP_Problem::intermediate_callback(
 {
     CNLP_Bool retval = 1;
     if (m_intermediate_cb && *m_intermediate_cb) {
+        const Ipopt::Number* x_values = nullptr;
+        Ipopt::Index x_count = 0;
+        if (ip_data != nullptr) {
+            Ipopt::SmartPtr<const Ipopt::IteratesVector> current_iterates = ip_data->curr();
+            if (Ipopt::IsValid(current_iterates)) {
+                Ipopt::SmartPtr<const Ipopt::Vector> current_x = current_iterates->x();
+                const auto* dense_x =
+                    dynamic_cast<const Ipopt::DenseVector*>(Ipopt::GetRawPtr(current_x));
+                if (dense_x != nullptr) {
+                    x_count = dense_x->Dim();
+                    x_values = dense_x->ExpandedValues();
+                }
+            }
+        }
         retval = (**m_intermediate_cb)(convert_algorithm_mode(mode), iter, obj_value, inf_pr, inf_du,
                 mu, d_norm, regularization_size, alpha_du,
-                alpha_pr, ls_trials, m_user_data);
+                alpha_pr, ls_trials, x_count, x_values, m_user_data);
     }
     return (retval!=0);
 }
@@ -357,4 +374,3 @@ void CNLP_Problem::finalize_solution(
     m_obj_sol = obj_value;
     // don't need to store the status, we get the status from the OptimizeTNLP method
 }
-

--- a/ipopt-sys/src/lib.rs
+++ b/ipopt-sys/src/lib.rs
@@ -455,8 +455,13 @@ mod tests {
         _alpha_du: CNLP_Number,
         _alpha_pr: CNLP_Number,
         _ls_trials: CNLP_Index,
+        x_count: CNLP_Index,
+        x: *const CNLP_Number,
         _user_data: CNLP_UserDataPtr,
     ) -> CNLP_Bool {
+        let x = unsafe { slice::from_raw_parts(x, x_count as usize) };
+        assert_eq!(x.len(), 4);
+        assert!(x.iter().all(|value| value.is_finite()));
         (inf_pr >= 1e-4) as CNLP_Bool
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ pub enum AlgorithmMode {
 /// Pieces of solver data available from Ipopt after each iteration inside the intermediate
 /// callback.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct IntermediateCallbackData {
+pub struct IntermediateCallbackData<'a> {
     /// Algorithm mode indicates which mode the algorithm is currently in.
     pub alg_mod: AlgorithmMode,
     /// The current iteration count.
@@ -506,6 +506,8 @@ pub struct IntermediateCallbackData {
     pub alpha_pr: Number,
     /// The number of backtracking line search steps (does not include second-order correction steps).
     pub ls_trials: Index,
+    /// The current primal iterate.
+    pub x: &'a [Number],
 }
 
 /// A data structure to store data returned by the solver.
@@ -528,7 +530,7 @@ pub struct SolveResult<'a, P: 'a> {
 /// information on the state of the optimization. This can be used to print some user-
 /// defined output. It also gives the user a way to terminate the optimization
 /// prematurely. If this method returns false, Ipopt will terminate the optimization.
-pub type IntermediateCallback<P> = fn(&mut P, IntermediateCallbackData) -> bool;
+pub type IntermediateCallback<P> = for<'a> fn(&mut P, IntermediateCallbackData<'a>) -> bool;
 
 /// Ipopt non-linear optimization problem solver.
 ///
@@ -959,10 +961,13 @@ impl<P: BasicProblem> Ipopt<P> {
         alpha_du: Number,
         alpha_pr: Number,
         ls_trials: Index,
+        x_count: Index,
+        x: *const Number,
         user_data: ffi::CNLP_UserDataPtr,
     ) -> Bool {
         let ip = &mut (*(user_data as *mut Ipopt<P>));
         if let Some(callback) = ip.intermediate_callback {
+            let x = slice::from_raw_parts(x, x_count as usize);
             (callback)(
                 &mut ip.nlp_interface,
                 IntermediateCallbackData {
@@ -980,6 +985,7 @@ impl<P: BasicProblem> Ipopt<P> {
                     alpha_du,
                     alpha_pr,
                     ls_trials,
+                    x,
                 },
             ) as Bool
         } else {

--- a/tests/constrained_newton.rs
+++ b/tests/constrained_newton.rs
@@ -25,15 +25,17 @@ struct NLP {
     lambda_start: Vec<f64>, // Save constraint multipliers for warm start
 }
 impl NLP {
-    fn intermediate_cb(&mut self, data: IntermediateCallbackData) -> bool {
+    fn intermediate_cb(&mut self, data: IntermediateCallbackData<'_>) -> bool {
         self.count_iterations_cb(data);
+        assert_eq!(data.x.len(), 4);
+        assert!(data.x.iter().all(|value| value.is_finite()));
         data.inf_pr >= 1e-4
     }
-    fn count_iterations_cb(&mut self, data: IntermediateCallbackData) -> bool {
+    fn count_iterations_cb(&mut self, data: IntermediateCallbackData<'_>) -> bool {
         self.iterations = data.iter_count as usize;
         true
     }
-    fn scaling_check_cb(&mut self, data: IntermediateCallbackData) -> bool {
+    fn scaling_check_cb(&mut self, data: IntermediateCallbackData<'_>) -> bool {
         self.count_iterations_cb(data);
         if self.iterations < 10 {
             // A panic here will hopefully produce a failure, but IIRC it is UB since it goes

--- a/tests/dynamic_problem_size.rs
+++ b/tests/dynamic_problem_size.rs
@@ -30,8 +30,9 @@ struct NLP {
 }
 
 impl NLP {
-    fn count_iterations_cb(&mut self, data: IntermediateCallbackData) -> bool {
+    fn count_iterations_cb(&mut self, data: IntermediateCallbackData<'_>) -> bool {
         self.iterations = data.iter_count as usize;
+        assert_eq!(data.x.len(), self.num_variables());
         true
     }
 

--- a/tests/unconstrained_approx_newton.rs
+++ b/tests/unconstrained_approx_newton.rs
@@ -28,8 +28,9 @@ struct NLP {
 }
 
 impl NLP {
-    fn count_iterations_cb(&mut self, data: IntermediateCallbackData) -> bool {
+    fn count_iterations_cb(&mut self, data: IntermediateCallbackData<'_>) -> bool {
         self.iterations = data.iter_count as usize;
+        assert_eq!(data.x.len(), 2);
         true
     }
 


### PR DESCRIPTION
This PR passes the current primal iterate through the intermediate callback stack for both crates in this repo.

What changed:
- `ipopt-sys`: extend the raw intermediate callback with `(x_count, x)` and forward `ip_data->curr()->x()` from the CNLP bridge
- `ipopt-sys`: add rebuild triggers for the CNLP shim / bindgen inputs
- `ipopt-sys`: bump `0.6.0 -> 0.7.0` because the raw callback signature changes
- `ipopt`: expose the current primal iterate on `IntermediateCallbackData` as `x: &'a [Number]`
- `ipopt`: thread the iterate slice through `Ipopt::intermediate_cb`
- `ipopt`: bump `0.6.0 -> 0.7.0` because the public callback payload changes
- keep the version constraints aligned so the safe crate depends on `ipopt-sys = "0.7"`
- extend the raw and safe callback tests to assert that the primal iterate is present, sized correctly, and finite

Commit structure:
1. raw-layer `ipopt-sys` callback plumbing
2. safe-layer `ipopt` callback exposure

Why one PR:
- the repo contains both crates
- the safe-layer API depends directly on the raw callback shape
- reviewing the two commits together makes the compatibility story and version bumps clearer

This supersedes the split PR approach; the full change is here.
