### PR TITLE
Fix UB when a constrained problem has no constraints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,12 +377,26 @@ impl<'a> From<i32> for IpoptOption<'a> {
     }
 }
 
-fn reconstruct_dual_slice<'a>(g: *const Number, num_dual_vars: usize) -> &'a [Number] {
-    if num_dual_vars == 0 {
+/// Build a slice from a pointer and a length, tolerating a null pointer when the length is zero.
+unsafe fn from_raw_parts_or_empty<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
+    if len == 0 {
         &[]
     } else {
-        unsafe { slice::from_raw_parts(g, num_dual_vars) }
+        slice::from_raw_parts(ptr, len)
     }
+}
+
+/// Mutable counterpart of `from_raw_parts_or_empty`.
+unsafe fn from_raw_parts_mut_or_empty<'a, T>(ptr: *mut T, len: usize) -> &'a mut [T] {
+    if len == 0 {
+        &mut []
+    } else {
+        slice::from_raw_parts_mut(ptr, len)
+    }
+}
+
+fn reconstruct_dual_slice<'a>(g: *const Number, num_dual_vars: usize) -> &'a [Number] {
+    unsafe { from_raw_parts_or_empty(g, num_dual_vars) }
 }
 
 /// The solution of the optimization problem including variables, bound multipliers and Lagrange
@@ -1062,14 +1076,14 @@ impl<P: NewtonProblem> Ipopt<P> {
         if values.is_null() {
             /* return the structure. */
             nlp.hessian_indices(
-                slice::from_raw_parts_mut(irow, nele_hess as usize),
-                slice::from_raw_parts_mut(jcol, nele_hess as usize),
+                from_raw_parts_mut_or_empty(irow, nele_hess as usize),
+                from_raw_parts_mut_or_empty(jcol, nele_hess as usize),
             ) as Bool
         } else {
             /* return the values. */
             let result = nlp.hessian_values(
                 slice::from_raw_parts(x, n as usize),
-                slice::from_raw_parts_mut(values, nele_hess as usize),
+                from_raw_parts_mut_or_empty(values, nele_hess as usize),
             ) as Bool;
             // This problem has no constraints so we can multiply each entry by the
             // objective factor.
@@ -1169,7 +1183,7 @@ impl<P: ConstrainedProblem> Ipopt<P> {
             }
         }
         if init_lambda != 0 {
-            let lambda = slice::from_raw_parts_mut(lambda, m as usize);
+            let lambda = from_raw_parts_mut_or_empty(lambda, m as usize);
             if !nlp.initial_constraint_multipliers(lambda) {
                 for i in 0..m as usize {
                     lambda[i] = 0.0;
@@ -1214,8 +1228,8 @@ impl<P: ConstrainedProblem> Ipopt<P> {
             slice::from_raw_parts_mut(x_l, n as usize),
             slice::from_raw_parts_mut(x_u, n as usize),
         ) && nlp.constraint_bounds(
-            slice::from_raw_parts_mut(g_l, m as usize),
-            slice::from_raw_parts_mut(g_u, m as usize),
+            from_raw_parts_mut_or_empty(g_l, m as usize),
+            from_raw_parts_mut_or_empty(g_u, m as usize),
         )) as Bool
     }
 
@@ -1232,7 +1246,7 @@ impl<P: ConstrainedProblem> Ipopt<P> {
         nlp.constraint(
             slice::from_raw_parts(x, n as usize),
             new_x != 0,
-            slice::from_raw_parts_mut(g, m as usize),
+            from_raw_parts_mut_or_empty(g, m as usize),
         ) as Bool
     }
 
@@ -1252,15 +1266,15 @@ impl<P: ConstrainedProblem> Ipopt<P> {
         if values.is_null() {
             /* return the structure of the Jacobian */
             nlp.constraint_jacobian_indices(
-                slice::from_raw_parts_mut(irow, nele_jac as usize),
-                slice::from_raw_parts_mut(jcol, nele_jac as usize),
+                from_raw_parts_mut_or_empty(irow, nele_jac as usize),
+                from_raw_parts_mut_or_empty(jcol, nele_jac as usize),
             ) as Bool
         } else {
             /* return the values of the Jacobian of the constraints */
             nlp.constraint_jacobian_values(
                 slice::from_raw_parts(x, n as usize),
                 new_x != 0,
-                slice::from_raw_parts_mut(values, nele_jac as usize),
+                from_raw_parts_mut_or_empty(values, nele_jac as usize),
             ) as Bool
         }
     }
@@ -1286,8 +1300,8 @@ impl<P: ConstrainedProblem> Ipopt<P> {
         if values.is_null() {
             /* return the structure. */
             nlp.hessian_indices(
-                slice::from_raw_parts_mut(irow, nele_hess as usize),
-                slice::from_raw_parts_mut(jcol, nele_hess as usize),
+                from_raw_parts_mut_or_empty(irow, nele_hess as usize),
+                from_raw_parts_mut_or_empty(jcol, nele_hess as usize),
             ) as Bool
         } else {
             /* return the values. */
@@ -1295,8 +1309,8 @@ impl<P: ConstrainedProblem> Ipopt<P> {
                 slice::from_raw_parts(x, n as usize),
                 new_x != 0,
                 obj_factor,
-                slice::from_raw_parts(lambda, m as usize),
-                slice::from_raw_parts_mut(values, nele_hess as usize),
+                from_raw_parts_or_empty(lambda, m as usize),
+                from_raw_parts_mut_or_empty(values, nele_hess as usize),
             ) as Bool
         }
     }
@@ -1319,7 +1333,7 @@ impl<P: ConstrainedProblem> Ipopt<P> {
         *use_x_scaling =
             nlp.variable_scaling(slice::from_raw_parts_mut(x_scaling, n as usize)) as Bool;
         *use_g_scaling =
-            nlp.constraint_scaling(slice::from_raw_parts_mut(g_scaling, m as usize)) as Bool;
+            nlp.constraint_scaling(from_raw_parts_mut_or_empty(g_scaling, m as usize)) as Bool;
         true as Bool
     }
 }
@@ -1956,6 +1970,39 @@ mod tests {
         // returned by solver_data must always be valid.
         assert_eq!(primal_variables, nlp.init_point.as_slice());
         assert_eq!(constraint_multipliers, vec![0.0; 2].as_slice());
+        assert_eq!(lower_bound_multipliers, vec![0.0; 4].as_slice());
+        assert_eq!(upper_bound_multipliers, vec![0.0; 4].as_slice());
+    }
+
+    /// Test that a constrained problem with no constraints can be constructed.
+    #[test]
+    fn zero_constraints_construction_test() {
+        let nlp = NlpConstrained {
+            num_vars: 4,
+            num_constraints: 0,
+            num_constraint_jac_nnz: 0,
+            num_hess_nnz: 10,
+            constraint_lower: vec![],
+            constraint_upper: vec![],
+            init_point: vec![1.0, 5.0, 5.0, 1.0],
+            lower: vec![1.0; 4],
+            upper: vec![5.0; 4],
+        };
+
+        let solver = Ipopt::new(nlp.clone()).expect("Failed to create Ipopt solver");
+        let SolverData {
+            solution:
+                Solution {
+                    primal_variables,
+                    constraint_multipliers,
+                    lower_bound_multipliers,
+                    upper_bound_multipliers,
+                },
+            ..
+        } = solver.solver_data();
+
+        assert_eq!(primal_variables, nlp.init_point.as_slice());
+        assert_eq!(constraint_multipliers, &[] as &[Number]);
         assert_eq!(lower_bound_multipliers, vec![0.0; 4].as_slice());
         assert_eq!(upper_bound_multipliers, vec![0.0; 4].as_slice());
     }

--- a/tests/zero_constraints.rs
+++ b/tests/zero_constraints.rs
@@ -1,0 +1,127 @@
+//   Copyright 2018 Egor Larionov
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+/**
+ * This test solves an unconstrained quadratic through the `ConstrainedProblem` interface, with the
+ * constraint count reported as zero. This is a valid configuration, and one that arises when the
+ * number of constraints is only known at runtime and happens to come out to zero.
+ */
+use approx::assert_relative_eq;
+
+use ipopt::*;
+
+struct NLP;
+
+impl BasicProblem for NLP {
+    fn num_variables(&self) -> usize {
+        1
+    }
+    fn bounds(&self, x_l: &mut [Number], x_u: &mut [Number]) -> bool {
+        x_l[0] = -1e20;
+        x_u[0] = 1e20;
+        true
+    }
+    fn initial_point(&self, x: &mut [Number]) -> bool {
+        x[0] = 5.0;
+        true
+    }
+    fn objective(&self, x: &[Number], _: bool, obj: &mut Number) -> bool {
+        *obj = (x[0] - 1.0) * (x[0] - 1.0);
+        true
+    }
+    fn objective_grad(&self, x: &[Number], _: bool, grad_f: &mut [Number]) -> bool {
+        grad_f[0] = 2.0 * (x[0] - 1.0);
+        true
+    }
+}
+
+impl ConstrainedProblem for NLP {
+    fn num_constraints(&self) -> usize {
+        0
+    }
+    fn num_constraint_jacobian_non_zeros(&self) -> usize {
+        0
+    }
+    fn constraint(&self, _: &[Number], _: bool, g: &mut [Number]) -> bool {
+        assert!(g.is_empty());
+        true
+    }
+    fn constraint_bounds(&self, g_l: &mut [Number], g_u: &mut [Number]) -> bool {
+        assert!(g_l.is_empty());
+        assert!(g_u.is_empty());
+        true
+    }
+    fn constraint_jacobian_indices(&self, rows: &mut [Index], cols: &mut [Index]) -> bool {
+        assert!(rows.is_empty());
+        assert!(cols.is_empty());
+        true
+    }
+    fn constraint_jacobian_values(&self, _: &[Number], _: bool, vals: &mut [Number]) -> bool {
+        assert!(vals.is_empty());
+        true
+    }
+
+    // Hessian Implementation
+    fn num_hessian_non_zeros(&self) -> usize {
+        1
+    }
+    fn hessian_indices(&self, rows: &mut [Index], cols: &mut [Index]) -> bool {
+        rows[0] = 0;
+        cols[0] = 0;
+        true
+    }
+    fn hessian_values(
+        &self,
+        _: &[Number],
+        _: bool,
+        obj_factor: Number,
+        lambda: &[Number],
+        vals: &mut [Number],
+    ) -> bool {
+        assert!(lambda.is_empty());
+        vals[0] = 2.0 * obj_factor;
+        true
+    }
+}
+
+#[test]
+fn zero_constraints_solve_test() {
+    let mut ipopt = Ipopt::new(NLP).unwrap();
+    ipopt.set_option("tol", 1e-9);
+    ipopt.set_option("mu_strategy", "adaptive");
+    ipopt.set_option("sb", "yes");
+    ipopt.set_option("print_level", 0);
+
+    let SolveResult {
+        solver_data:
+            SolverDataMut {
+                solution:
+                    Solution {
+                        primal_variables: x,
+                        constraint_multipliers,
+                        ..
+                    },
+                ..
+            },
+        constraint_values,
+        objective_value: obj,
+        status,
+    } = ipopt.solve();
+
+    assert_eq!(status, SolveStatus::SolveSucceeded);
+    assert_relative_eq!(x[0], 1.0, epsilon = 1e-8);
+    assert_relative_eq!(obj, 0.0, epsilon = 1e-8);
+    assert!(constraint_multipliers.is_empty());
+    assert!(constraint_values.is_empty());
+}


### PR DESCRIPTION
Hello @elrnv,
I hope you are doing good,

Currently `Ipopt::new(nlp)` is UB whenever `nlp` reports `num_constraints() == 0`.
This is reachable from safe code, and the configuration is accepted by the constructor. I understand we could use the unconstrained problem API, but sometimes we know constraints at runtime.

The test added in this PR aborts on `master`, but the same test passes under `--release`.
The UB is present in both profiles but only the debug-gated precondition check observes it. Release is fine because the empty slice is never read.

This PR fixes it by using `from_raw_parts_or_empty` and a mutable version of it, similar to the already existing `reconstruct_dual_slice`

Tested w/ Ipopt 3.14.20 on Fedora 44, rustc 1.97.